### PR TITLE
fix: action icon/color options fallback to state when hvac_action is not supported

### DIFF
--- a/src/cards/thermostat-card/thermostat-card.ts
+++ b/src/cards/thermostat-card/thermostat-card.ts
@@ -147,7 +147,11 @@ export class ThermostatCard extends MushroomBaseElement implements LovelaceCard 
 
         const icon =
             this._config.icon ||
-            (!!this._config.use_action_icon && actionIcon ? actionIcon : stateIcon(entity));
+            (!!this._config.use_action_icon
+                ? hvac_action
+                    ? actionIcon
+                    : stateIcon(entity)
+                : "mdi:thermostat");
 
         const step = getStepSize(this.hass, entity);
 
@@ -171,6 +175,9 @@ export class ThermostatCard extends MushroomBaseElement implements LovelaceCard 
         if (this._config?.use_action_color && hvac_action && hvac_action !== "idle") {
             iconStyle["--icon-color"] = `rgb(var(--rgb-action-climate-${hvac_action}))`;
             iconStyle["--shape-color"] = `rgba(var(--rgb-action-climate-${hvac_action}), 0.25)`;
+        } else if (this._config?.use_action_color && entity.state !== "off") {
+            iconStyle["--icon-color"] = `rgb(var(--rgb-state-climate-${entity.state}))`;
+            iconStyle["--shape-color"] = `rgba(var(--rgb-state-climate-${entity.state}), 0.25)`;
         }
 
         const rtl = computeRTL(this.hass);

--- a/src/translations/en-thermostat.json
+++ b/src/translations/en-thermostat.json
@@ -14,8 +14,8 @@
                 "use_entity_picture": "Use entity picture?"
             },
             "thermostat": {
-                "use_action_color": "Icon action color?",
-                "use_action_icon": "Icon action?",
+                "use_action_color": "Icon action/state color?",
+                "use_action_icon": "Icon action/state?",
                 "show_mode_control": "Mode control?",
                 "show_temp_control": "Temperature control?",
                 "show_temp_indicators": "Temperature control indicators?",

--- a/src/utils/icons/domain-icon.ts
+++ b/src/utils/icons/domain-icon.ts
@@ -2,6 +2,7 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { UpdateEntity, updateIsInstalling } from "../../ha/data/update";
 import { alarmPanelIcon } from "./alarm-panel-icon";
 import { binarySensorIcon } from "./binary-sensor-icon";
+import { climateIcon } from "./climate-icon";
 import { coverIcon } from "./cover-icon";
 import { sensorIcon } from "./sensor-icon";
 
@@ -69,6 +70,9 @@ export function domainIcon(domain: string, entity?: HassEntity, state?: string):
                 default:
                     return "mdi:gesture-tap-button";
             }
+
+        case "climate":
+            return climateIcon(state);
 
         case "cover":
             return coverIcon(state, entity);


### PR DESCRIPTION
When an entity doesn't support the hvac_action attribute the action icon and action icon color options now fall back to using the state.