### PR TITLE
Fix auto logic for heat-/cool-only thermostats

### DIFF
--- a/src/cards/thermostat-card/utils.ts
+++ b/src/cards/thermostat-card/utils.ts
@@ -17,8 +17,6 @@ export const getStepSize = (hass: HomeAssistant, entity: ClimateEntity): number 
     return entity.attributes.target_temp_step ?? systemStep;
 };
 
-export const supportTargetTemperatureRange = (entity: ClimateEntity) => supportsFeature(entity, 2);
-
 export const supportsCoolOnly = (entity: ClimateEntity) => {
     const modes = entity.attributes.hvac_modes;
     return !modes.includes("heat") && modes.includes("cool");
@@ -32,7 +30,7 @@ export const supportsHeatOnly = (entity: ClimateEntity) => {
 export const getTargetTemps = (entity: ClimateEntity): [number | undefined, number | undefined] => {
     const { target_temp_high, target_temp_low, temperature } = entity.attributes;
 
-    if (supportTargetTemperatureRange(entity)) return [target_temp_low, target_temp_high];
-    if (supportsHeatOnly(entity)) return [target_temp_low ?? temperature, undefined];
-    return [undefined, target_temp_high ?? temperature];
+    if (supportsHeatOnly(entity) || entity.state == "heat") return [target_temp_low ?? temperature, undefined];
+    if (supportsCoolOnly(entity) || entity.state == "cool") [undefined, target_temp_high ?? temperature];
+    return [target_temp_low, target_temp_high];
 };

--- a/src/cards/thermostat-card/utils.ts
+++ b/src/cards/thermostat-card/utils.ts
@@ -30,7 +30,7 @@ export const supportsHeatOnly = (entity: ClimateEntity) => {
 export const getTargetTemps = (entity: ClimateEntity): [number | undefined, number | undefined] => {
     const { target_temp_high, target_temp_low, temperature } = entity.attributes;
 
-    if (supportsHeatOnly(entity) || entity.state == "heat") return [target_temp_low ?? temperature, undefined];
-    if (supportsCoolOnly(entity) || entity.state == "cool") [undefined, target_temp_high ?? temperature];
+    if (supportsHeatOnly(entity) || entity.state === "heat") return [target_temp_low ?? temperature, undefined];
+    if (supportsCoolOnly(entity) || entity.state === "cool") [undefined, target_temp_high ?? temperature];
     return [target_temp_low, target_temp_high];
 };


### PR DESCRIPTION




## Description
This fixes a bug that was introduced when handling heat-only and cool-only thermostats that caused thermostats supporting both to render incorrect temperatures within the slider. This occurs because of a short-circuit that exists when checking for support for heat_cool which caused them to always be treated as being in heat_cool mode.

This fix now properly checks for heat-only or cool-only support in addition to the thermostats being in the relevant heat or cool state to render those specific cases. For all other cases (auto or heat_cool mode in a thermostat that supports both, or supports target ranges), we default back to the previous logic of using the target ranges to render both sliders. This no longer requires us to check for target range support since it is normally required in heat_cool and auto mode on thermostats that support both heating and cooling.

## Related Issue
Fixes bug introduced in #20 when fixing #19.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Tested locally on thermostats which support both heat/cool as well as cool-only thermostats to ensure it renders correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
